### PR TITLE
Untitled

### DIFF
--- a/YouTube5.safariextension/inject.js
+++ b/YouTube5.safariextension/inject.js
@@ -3,8 +3,10 @@ var players = {};
 document.addEventListener('beforeload', function(event) {
 	// for some reason the url doesn't stay in the event when its passed to the global page, so we have to set it as the message
 	var result = safari.self.tab.canLoad(event, event.url);
-	
+
 	if (result === 'video') {
+        	if (!event.target.parentNode) return;
+
 		event.preventDefault();
 		
 		var playerId = Math.floor(Math.random()*1000000000);


### PR DESCRIPTION
Hi, greneholt,

With youtube5 2.0, I saw this message in the error console:

```
TypeError: Result of expression 'replace.parentNode' [null] is not an object.
safari-extension://com.verticalforest.youtube5-747RDEXRZ3/789bcd24/player.js:42
```

When I play this video http://www.youtube.com/watch?v=H1ALHlEJ8ZE&feature=sub
However, the video is still loaded and can be played.

I did manage  to eliminate the error message and it looks like the `<embed>` element triggers a `beforeLoad` event even before it's inserted into the DOM. Anyway thanks for the great work, I'm really enjoying it. :)
