### PR TITLE
Fixe youtube.com SWF url since 2010/12/09 site update

### DIFF
--- a/YouTube5.safariextension/global.html
+++ b/YouTube5.safariextension/global.html
@@ -59,7 +59,7 @@ var youTubeMeta = function(text, flashvars) {
 	(data.fmt_url_map || flashvars.fmt_url_map).split(',').forEach(function(format) {
 		var pair = format.split('|');
 		if (youTubeFormats[pair[0]]) {
-			meta.formats[youTubeFormats[pair[0]]] = pair[1];
+			meta.formats[youTubeFormats[pair[0]]] = pair[1] + "&app=youtube_mobile";
 		}
 	});
 	


### PR DESCRIPTION
Youtube update their swf URLs a little bit so the inject.js fail to detect it properly.

This commit fixes it with the new URL:

https://github.com/gugod/youtube5/commit/0e95655ccae9cec2740e17cecd9119b7eeafb7d6
