### PR TITLE
Removes "Upgrade to flash version 10" banner from Youtube

### DIFF
--- a/YouTube5.safariextension/inject.css
+++ b/YouTube5.safariextension/inject.css
@@ -3,6 +3,11 @@
 	border: none !important;
 }
 
+/* Hide youtube "Update Flash version" banner */
+#flash10-promo-div {
+	display: none !important;
+}
+
 /* Hide Vimeo overlay */
 .q.f .ae {
 	display: none !important;


### PR DESCRIPTION
This is a simple change that removes an annoying banner below the youtube video if you don't have flash installed.
