### PR TITLE
I've added support for Yandex.Video embeds

### DIFF
--- a/YouTube5.safariextension/Info.plist
+++ b/YouTube5.safariextension/Info.plist
@@ -23,6 +23,10 @@
 	<dict>
 		<key>Scripts</key>
 		<dict>
+			<key>End</key>
+			<array>
+				<string>inject-end.js</string>
+			</array>
 			<key>Start</key>
 			<array>
 				<string>inject.js</string>

--- a/YouTube5.safariextension/Settings.plist
+++ b/YouTube5.safariextension/Settings.plist
@@ -130,5 +130,45 @@
 		<key>Key</key>
 		<string>volume</string>
 	</dict>
+	<dict>
+		<key>Title</key>
+		<string>Yandex.Video Options</string>
+		<key>Type</key>
+		<string>Group</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<true/>
+		<key>Key</key>
+		<string>enableYandexVideo</string>
+		<key>Title</key>
+		<string>Enable for Yandex.Video videos</string>
+		<key>Type</key>
+		<string>CheckBox</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>HD (H.264) FLV</string>
+		<key>Key</key>
+		<string>yandexVideoFormat</string>
+		<key>Title</key>
+		<string>Default Yandex.Video Format</string>
+		<key>Titles</key>
+		<array>
+			<string>HD (H.264) FLV</string>
+			<string>Medium (H.264) FLV</string>
+			<string>Low (H.264) FLV</string>
+			<string>Low FLV</string>
+		</array>
+		<key>Type</key>
+		<string>PopUpButton</string>
+		<key>Values</key>
+		<array>
+			<string>HD (H.264) FLV</string>
+			<string>Medium (H.264) FLV</string>
+			<string>Low (H.264) FLV</string>
+			<string>Low FLV</string>
+		</array>
+	</dict>
 </array>
 </plist>

--- a/YouTube5.safariextension/global.html
+++ b/YouTube5.safariextension/global.html
@@ -35,7 +35,7 @@ var youTubeMeta = function(text, flashvars) {
 	
 	var data = parseUrlEncoded(text);
 	
-	if (data.errorcode && (!flashvars || !flashvars.fmt_url_map)) {
+	if (data.errorcode && (!flashvars || !flashvars.url_encoded_fmt_stream_map)) {
 		meta.error = data.reason;
 		return meta;
 	}
@@ -48,18 +48,18 @@ var youTubeMeta = function(text, flashvars) {
 	35 - FLV 480p
 	37 - MP4 1080p (HD)
 	38 - MP4 Original (HD)
-	43 - WebM 480p
+	43 - WebM 360p
+	44 - WebM 480p
 	45 - WebM 720p (HD)
 	*/
 	
 	var youTubeFormats = { 5: '240p FLV', 18: '360p', 22: '720p', 37: '1080p' };
 	
 	meta.formats = {};
-	// use the flashvars if the video info couldn't be retreived
-	(data.fmt_url_map || flashvars.fmt_url_map).split(',').forEach(function(format) {
-		var pair = format.split('|');
-		if (youTubeFormats[pair[0]]) {
-			meta.formats[youTubeFormats[pair[0]]] = pair[1];
+	(data.url_encoded_fmt_stream_map || flashvars.url_encoded_fmt_stream_map).split(",").forEach(function(encodedFormat) {
+		format = parseUrlEncoded(encodedFormat);
+		if (youTubeFormats[parseInt(format.itag)]) {
+			meta.formats[youTubeFormats[parseInt(format.itag)]] = format.url;
 		}
 	});
 	

--- a/YouTube5.safariextension/global.html
+++ b/YouTube5.safariextension/global.html
@@ -241,13 +241,26 @@ var yandexVideoMeta = function(data, xml) {
 	return meta;
 }
 
-var loadYandexVideo = function(playerId, data, event) {
+var loadYandexVideo = function(playerId, event, domain, login, storageDirectory) {
+	var data = {};
+	data.domain           = domain;
+	data.login            = login;
+	data.storageDirectory = storageDirectory;
+	data.siteUrl          = 'http://video.' + domain + '/';
+	data.clipStorageUrl   = 'http://streaming.video.' + domain + '/get/';
+	data.storageUrl       = 'http://flv.video.' + domain + '/get/';
+	data.getTokenUrl      = 'http://static.video.' + domain + '/get-token/';
+
+	if (domain == 'yandex-team.ru') {
+		data.storageUrl = 'http://static.video.yandex-team.ru/get/';
+	}
+
 	var req = new XMLHttpRequest();
 	var getTokenUrl = data.getTokenUrl + data.login + '/' + data.storageDirectory;
 	req.open('GET', getTokenUrl, true);
 	req.onreadystatechange = function(ev) {
 		if (req.readyState === 4 && req.status === 200) {
-			data.token = /\<token\>([^\s]+)\<\/token\>/.exec(req.responseText)[1];
+			data.token = req.responseXML.querySelector('token').textContent;
 
 			var getMetadataUrl = data.storageUrl + data.login + '/' + data.storageDirectory + '/0h.xml';
 			var req2 = new XMLHttpRequest();
@@ -270,14 +283,29 @@ var loadYandexVideo = function(playerId, data, event) {
 	req.send(null);
 }
 
+var isYandexVideoUrl = function(url) {
+	return (safari.extension.settings.enableYandexVideo &&
+		 (/^http\:\/\/static\.video\.yandex(\-team)?\.ru\/(.+)\/(.+)\/(.+)\/$/i.test(url) ||
+		  /^http\:\/\/video\.(yandex(?:\-team)?\.ru)\/users\/(.+)\/view\/(.+)(?:\/)?$/i.test(url)));
+}
+
 var canLoad = function(event) {
 	url = event.message;
 	
 	if ((safari.extension.settings.enableYouTube && (/^https?:\/\/www\.youtube(?:\-nocookie)?\.com\/(?:v|embed)\//i.test(url) || /^https?:\/\/s\.ytimg\.com\/yt\/swf(?:bin)?\/watch/i.test(url))) ||
 		(safari.extension.settings.enableVimeo && (/^https?:\/\/assets\.vimeo\.com\/flash\/moog/i.test(url) || /vimeo\.com\/moogaloop\.swf/i.test(url) || /\/moogaloop/i.test(url) || /^https?:\/\/player.vimeo.com\/video\//.test(url))) || 
 		(safari.extension.settings.enableFacebook && /^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/wn29KX6UvhD\.swf/i.test(url)) ||
-		(safari.extension.settings.enableYandexVideo && /^http\:\/\/static\.video\.yandex(\-team)?\.ru\/(.+)\/(.+)\/(.+)\/$/i.test(url))) {
+		isYandexVideoUrl(url)) {
 		event.message = 'video';
+	}
+};
+
+var canLoad2 = function(event) {
+	url = event.message.url;
+	console.log('canLoad2: ' + url);
+
+	if (isYandexVideoUrl(url)) {
+		event.target.page.dispatchMessage("doLoad2", event.message);
 	}
 };
 
@@ -308,19 +336,10 @@ var loadVideo = function(event) {
 	} else if (/^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/wn29KX6UvhD\.swf/i.test(url)) {
 		var data = parseUrlEncoded(flashvars);
 		loadFacebookVideo(playerId, data, event);
-	} else if (m = url.match(/^http\:\/\/static\.video\.yandex(\-team)?\.ru\/(.+)\/(.+)\/(.+)\/$/i)) {
-		var domain = m[1];
-		if (domain == undefined) domain = '';
-		domain = 'yandex' + domain + '.ru';
-
-		var data = {};
-		data.login            = m[3];
-		data.storageDirectory = m[4];
-		data.siteUrl          = 'http://video.' + domain + '/';
-		data.clipStorageUrl   = 'http://streaming.video.' + domain + '/get/';
-		data.storageUrl       = 'http://flv.video.' + domain + '/get/';
-		data.getTokenUrl      = 'http://static.video.' + domain + '/get-token/';
-		loadYandexVideo(playerId, data, event);
+	} else if (m = url.match(/^http\:\/\/static\.video\.(yandex(?:\-team)?\.ru)\/(.+)\/(.+)\/(.+)(?:\/)?$/i)) {
+		loadYandexVideo(playerId, event, m[1], m[3], m[4]);
+	} else if (m = url.match(/^http\:\/\/video\.(yandex(?:\-team)?\.ru)\/users\/(.+)\/view\/(.+)(?:\/)?$/i)) {
+		loadYandexVideo(playerId, event, m[1], m[2], event.message.storageDirectory);
 	} else {
 		var meta = { error: 'Unknown video URL<br />' + url };
 		injectVideo(event, playerId, meta);
@@ -334,6 +353,8 @@ var updateVolume = function(event) {
 safari.application.addEventListener("message", function(event) {
 	if (event.name == 'canLoad') {
 		canLoad(event);
+	} else if (event.name == 'canLoad2') {
+		canLoad2(event);
 	} else if (event.name == 'loadVideo') {
 		loadVideo(event);
 	} else if (event.name == 'updateVolume') {

--- a/YouTube5.safariextension/global.html
+++ b/YouTube5.safariextension/global.html
@@ -185,12 +185,97 @@ var loadFacebookVideo = function(playerId, data, event) {
 	injectVideo(event, playerId, meta);
 };
 
+var yandexVideoMeta = function(text, data) {
+	var meta = {};
+	meta.formats = {};
+
+	data.id = /\bid\=\"(\d+)\"/.exec(text)[1];
+	data.title = /\<title\>(.+)\<\/title\>/.exec(text)[1];
+
+	var yandexVideoFormats = {
+		'flv_low': {
+			'description': 'Low FLV',
+			'fileName': '0.flv'
+		},
+		'flv_h264_low': {
+			'description': 'Low (H.264) FLV',
+			'fileName': 'm450x334.flv'
+		},
+		'flv_h264_med': {
+			'description': 'Medium (H.264) FLV',
+			'fileName': 'medium.flv'
+		},
+		'flv_h264_hd_720p': {
+			'description': 'HD (H.264) FLV',
+			'fileName': 'm1280x720.flv'
+		}
+	};
+
+	var formats = []
+	if (/\<\/flv_low\>/.exec(text) != null) formats.push('flv_low');
+	if (/\<\/flv_h264_low\>/.exec(text) != null) formats.push('flv_h264_low');
+	if (/\<\/flv_h264_med\>/.exec(text) != null) formats.push('flv_h264_med');
+	if (/\<\/flv_h264_hd_720p\>/.exec(text) != null) formats.push('flv_h264_hd_720p');
+
+	formats.forEach(function(format) {
+		var videoFile = yandexVideoFormats[format].fileName;
+		videoFile = data.clipStorageUrl + data.login + '/' + data.storageDirectory + '/' + videoFile + '?token=' + data.token;
+		meta.formats[yandexVideoFormats[format].description] = videoFile;
+
+		meta.useFormat = yandexVideoFormats[format].description;
+	});
+
+	var defaultFormat = safari.extension.settings.yandexVideoFormat;
+	if (meta.formats[defaultFormat]) {
+		meta.useFormat = defaultFormat;
+	}
+
+	meta.poster = data.storageUrl + data.login + '/' + data.storageDirectory + '/m450x334.jpg';
+	meta.title = data.title;
+	meta.author = data.login;
+	meta.authorLink = data.siteUrl + 'users/' + data.login;
+	meta.link =  data.siteUrl + 'users/' + data.login + '/view/' + data.id + '/';
+	meta.from = 'Yandex.Video';
+
+	return meta;
+}
+
+var loadYandexVideo = function(playerId, data, event) {
+	var req = new XMLHttpRequest();
+	var getTokenUrl = data.getTokenUrl + data.login + '/' + data.storageDirectory;
+	req.open('GET', getTokenUrl, true);
+	req.onreadystatechange = function(ev) {
+		if (req.readyState === 4 && req.status === 200) {
+			data.token = /\<token\>([^\s]+)\<\/token\>/.exec(req.responseText)[1];
+
+			var getMetadataUrl = data.storageUrl + data.login + '/' + data.storageDirectory + '/0h.xml';
+			var req2 = new XMLHttpRequest();
+			req2.open('GET', getMetadataUrl, true);
+			req2.onreadystatechange = function(ev2) {
+				if (req2.readyState === 4 && req2.status === 200) {
+					var meta = yandexVideoMeta(req2.responseText, data);
+					injectVideo(event, playerId, meta);
+				} else if (req2.readyState === 4 && req2.status != 200) {
+					var meta = { error: 'Error2 loading Yandex.Video video' };
+					injectVideo(event, playerId, meta);
+				}
+			};
+			req2.send(null);
+		} else if (req.readyState === 4 && req.status != 200) {
+			var meta = { error: 'Error loading Yandex.Video video' };
+			injectVideo(event, playerId, meta);
+		}
+	};
+	req.send(null);
+}
+
 var canLoad = function(event) {
 	url = event.message;
 	
 	if ((safari.extension.settings.enableYouTube && (/^https?:\/\/www\.youtube(?:\-nocookie)?\.com\/(?:v|embed)\//i.test(url) || /^https?:\/\/s\.ytimg\.com\/yt\/swf(?:bin)?\/watch/i.test(url))) ||
 		(safari.extension.settings.enableVimeo && (/^https?:\/\/assets\.vimeo\.com\/flash\/moog/i.test(url) || /vimeo\.com\/moogaloop\.swf/i.test(url) || /\/moogaloop/i.test(url) || /^https?:\/\/player.vimeo.com\/video\//.test(url))) || 
-		(safari.extension.settings.enableFacebook && /^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/wn29KX6UvhD\.swf/i.test(url))) {
+		(safari.extension.settings.enableFacebook && /^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/wn29KX6UvhD\.swf/i.test(url)) ||
+		(safari.extension.settings.enableYandexVideo && /^http\:\/\/static\.video\.yandex(\-team)?\.ru\/(.+)\/(.+)\/(.+)\/$/i.test(url))) {
 		event.message = 'video';
 	}
 };
@@ -222,6 +307,19 @@ var loadVideo = function(event) {
 	} else if (/^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/wn29KX6UvhD\.swf/i.test(url)) {
 		var data = parseUrlEncoded(flashvars);
 		loadFacebookVideo(playerId, data, event);
+	} else if (m = url.match(/^http\:\/\/static\.video\.yandex(\-team)?\.ru\/(.+)\/(.+)\/(.+)\/$/i)) {
+		var domain = m[1];
+		if (domain == undefined) domain = '';
+		domain = 'yandex' + domain + '.ru';
+
+		var data = {};
+		data.login            = m[3];
+		data.storageDirectory = m[4];
+		data.siteUrl          = 'http://video.' + domain + '/';
+		data.clipStorageUrl   = 'http://streaming.video.' + domain + '/get/';
+		data.storageUrl       = 'http://flv.video.' + domain + '/get/';
+		data.getTokenUrl      = 'http://static.video.' + domain + '/get-token/';
+		loadYandexVideo(playerId, data, event);
 	} else {
 		var meta = { error: 'Unknown video URL<br />' + url };
 		injectVideo(event, playerId, meta);

--- a/YouTube5.safariextension/global.html
+++ b/YouTube5.safariextension/global.html
@@ -185,44 +185,45 @@ var loadFacebookVideo = function(playerId, data, event) {
 	injectVideo(event, playerId, meta);
 };
 
-var yandexVideoMeta = function(text, data) {
+var yandexVideoMeta = function(data, xml) {
 	var meta = {};
 	meta.formats = {};
 
-	data.id = /\bid\=\"(\d+)\"/.exec(text)[1];
-	data.title = /\<title\>(.+)\<\/title\>/.exec(text)[1];
+	data.id = xml.querySelector('film').getAttribute('id');
+	data.title = xml.querySelector('title').textContent;
 
-	var yandexVideoFormats = {
-		'flv_low': {
+	var yandexVideoFormats = [
+		{
+			'id': 'flv_low',
 			'description': 'Low FLV',
 			'fileName': '0.flv'
 		},
-		'flv_h264_low': {
+		{
+			'id': 'flv_h264_low',
 			'description': 'Low (H.264) FLV',
 			'fileName': 'm450x334.flv'
 		},
-		'flv_h264_med': {
+		{
+			'id': 'flv_h264_med',
 			'description': 'Medium (H.264) FLV',
 			'fileName': 'medium.flv'
 		},
-		'flv_h264_hd_720p': {
+		{
+			'id': 'flv_h264_hd_720p',
 			'description': 'HD (H.264) FLV',
 			'fileName': 'm1280x720.flv'
 		}
-	};
+	];
 
-	var formats = []
-	if (/\<\/flv_low\>/.exec(text) != null) formats.push('flv_low');
-	if (/\<\/flv_h264_low\>/.exec(text) != null) formats.push('flv_h264_low');
-	if (/\<\/flv_h264_med\>/.exec(text) != null) formats.push('flv_h264_med');
-	if (/\<\/flv_h264_hd_720p\>/.exec(text) != null) formats.push('flv_h264_hd_720p');
+	yandexVideoFormats.forEach(function(format) {
+		if (!xml.querySelector(format.id))
+			return;
 
-	formats.forEach(function(format) {
-		var videoFile = yandexVideoFormats[format].fileName;
+		var videoFile = format.fileName;
 		videoFile = data.clipStorageUrl + data.login + '/' + data.storageDirectory + '/' + videoFile + '?token=' + data.token;
-		meta.formats[yandexVideoFormats[format].description] = videoFile;
+		meta.formats[format.description] = videoFile;
 
-		meta.useFormat = yandexVideoFormats[format].description;
+		meta.useFormat = format.description;
 	});
 
 	var defaultFormat = safari.extension.settings.yandexVideoFormat;
@@ -253,7 +254,7 @@ var loadYandexVideo = function(playerId, data, event) {
 			req2.open('GET', getMetadataUrl, true);
 			req2.onreadystatechange = function(ev2) {
 				if (req2.readyState === 4 && req2.status === 200) {
-					var meta = yandexVideoMeta(req2.responseText, data);
+					var meta = yandexVideoMeta(data, req2.responseXML);
 					injectVideo(event, playerId, meta);
 				} else if (req2.readyState === 4 && req2.status != 200) {
 					var meta = { error: 'Error2 loading Yandex.Video video' };

--- a/YouTube5.safariextension/inject-end.js
+++ b/YouTube5.safariextension/inject-end.js
@@ -1,0 +1,54 @@
+if (/^http\:\/\/video\.(yandex(?:\-team)?\.ru)\/users\/(.+)\/view\/(.+)(?:\/)?$/i.test(document.location.href)) {
+	var movies = {};
+
+	function findMoviePlayers() {
+		var roots = document.querySelectorAll('[class=h-movie-player]');
+		for (var i = 0; i < roots.length; ++i) {
+			var root = roots[i];
+			var js = root.querySelector('script');
+			if (js == null)
+				continue;
+			var login = /login\s*\:\s*'([^\s]+)'/.exec(js.innerHTML)[1]; // it's escaped
+			var storage_directory = /storage_directory\s*\:\s*'([^\s]+)'/.exec(js.innerHTML)[1];
+			if (login == null || storage_directory == null)
+				continue;
+
+			var data = {}
+			data.url    = document.location.href;
+			data.target = root;
+			data.width  = 450;
+			data.height = 337;
+			data.login  = login;
+			data.storageDirectory = storage_directory;
+
+			var playerId = Math.round(Math.random()*1000000000);
+			movies[playerId] = data;
+		}
+	}
+
+	findMoviePlayers();
+
+	for (var playerId in movies) {
+		var p = movies[playerId];
+		safari.self.tab.dispatchMessage("canLoad2", {
+			url: p.url,
+			playerId: playerId
+		});
+	}
+
+	safari.self.addEventListener("message", function(event) {
+		if (event.name === "doLoad2") {
+			var playerId = event.message.playerId;
+			var p = movies[playerId];
+			if (p) {
+				players[playerId] = newPlayer(p.target, p.width, p.height);
+				safari.self.tab.dispatchMessage("loadVideo", {
+					url: p.url,
+					playerId: playerId,
+					flashvars: null,
+					storageDirectory: p.storageDirectory
+				});
+			}
+		}
+	}, true);
+}


### PR DESCRIPTION
Hi,

Currently it works only in Safari 5.1 (as there's a bug in 5.0 that prevents redirected video stream to actually play in browser) and Perian needs to be installed, as all the available files are in .flv containers (even if they're H.264 inside).
