### PR TITLE
Remove support for Vimeo (not-flash) replacement

### DIFF
--- a/YouTube5.safariextension/global.html
+++ b/YouTube5.safariextension/global.html
@@ -190,7 +190,7 @@ var canLoad = function(event) {
 	var url = event.message;
 
 	if ((safari.extension.settings.enableYouTube && (/^https?:\/\/(?:www\.)?youtube(?:\-nocookie)?\.com\/(?:v|embed)\//i.test(url) || /^https?:\/\/s\.ytimg\.com\/yt\/swf(?:bin)?\/watch/i.test(url))) ||
-		(safari.extension.settings.enableVimeo && (/^https?:\/\/assets\.vimeo\.com\/flash\/moog/i.test(url) || /vimeo\.com\/moogaloop\.swf/i.test(url) || /\/moogaloop/i.test(url) || /^https?:\/\/player.vimeo.com\/video\//.test(url))) ||
+		(safari.extension.settings.enableVimeo && (/^https?:\/\/assets\.vimeo\.com\/flash\/moog/i.test(url) || /vimeo\.com\/moogaloop\.swf/i.test(url) || /\/moogaloop/i.test(url) )) ||
 		(safari.extension.settings.enableFacebook && /^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/WE6KXRY0dum\.swf/i.test(url))) {
 		event.message = 'video';
 	}
@@ -217,9 +217,6 @@ var loadVideo = function(event) {
 	} else if (/\/moogaloop/i.test(url)) {
 		var data = parseUrlEncoded(flashvars);
 		loadVimeoVideo(playerId, data.clip_id, false, event);
-	} else if (m = url.match(/^https?:\/\/player.vimeo.com\/video\/(\d+)/i)) {
-		var clipId = m[1];
-		loadVimeoVideo(playerId, clipId, false, event);
 	} else if (/^https?:\/\/([a-z\-\.]+)?static\.ak\.facebook\.com\/rsrc.php\/v1\/yf\/r\/WE6KXRY0dum\.swf/i.test(url)) {
 		var data = parseUrlEncoded(flashvars);
 		loadFacebookVideo(playerId, data, event);


### PR DESCRIPTION
Currently embedded vimeo videos in the form "player.vimeo.com/video/" seem to 404, see
http://devour.com/video/ka-bar-knives/ for one that was broken for me.
With the youtube5 plugin disabled this video works without flash installed so
better to just use the vimeo player than to break it
