### PR TITLE
Disable history.pushState to make YouTube load a new page when navigating to a suggested video

### DIFF
--- a/YouTube5.safariextension/Info.plist
+++ b/YouTube5.safariextension/Info.plist
@@ -62,6 +62,10 @@
 	<dict>
 		<key>Scripts</key>
 		<dict>
+			<key>End</key>
+			<array>
+				<string>end.js</string>
+			</array>
 			<key>Start</key>
 			<array>
 				<string>util.js</string>

--- a/YouTube5.safariextension/end.js
+++ b/YouTube5.safariextension/end.js
@@ -1,0 +1,6 @@
+// Make YouTube load a new page when navigating to a suggested video
+if (location.hostname === "www.youtube.com" && window === window.top) {
+	var script = document.createElement("script");
+	script.text = "history.pushState = null;";
+	document.body.appendChild(script);
+}


### PR DESCRIPTION
Proposed fix for issue #41.
