### PR TITLE
Allow player to fill all available space

### DIFF
--- a/src/player.coffee
+++ b/src/player.coffee
@@ -15,8 +15,8 @@ class Player
     @placeholder.setAttribute "data-clean", "yes" # prevent Feedly from stripping style attributes
 
     @container = create("div", @placeholder, "youtube5container")
-    @container.style.width = @width + "px"
-    @container.style.height = @height + "px"
+    @container.style.width = "100%"
+    @container.style.height = "100%"
     @container.style.position = "relative"
     @container.style.margin = "0 auto"
 
@@ -91,8 +91,12 @@ class Player
       width = width
       height = Math.round(width / nativeAspectRatio)
 
-    @container.style.width = width + "px"
-    @container.style.height = height + "px"
+    if @floating
+      @container.style.width = width + "px"
+      @container.style.height = height + "px"
+    else
+      @container.style.width = "100%"
+      @container.style.height = "100%"
     return [width, height]
 
   updateTime: =>

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -15,8 +15,8 @@ class Player
     @placeholder.setAttribute "data-clean", "yes" # prevent Feedly from stripping style attributes
 
     @container = create("div", @placeholder, "youtube5container")
-    @container.style.width = "100%"
-    @container.style.height = "100%"
+    @container.style.width = @width + "px"
+    @container.style.height = @height + "px"
     @container.style.position = "relative"
     @container.style.margin = "0 auto"
 
@@ -91,12 +91,8 @@ class Player
       width = width
       height = Math.round(width / nativeAspectRatio)
 
-    if @floating
-      @container.style.width = width + "px"
-      @container.style.height = height + "px"
-    else
-      @container.style.width = "100%"
-      @container.style.height = "100%"
+    @container.style.width = width + "px"
+    @container.style.height = height + "px"
     return [width, height]
 
   updateTime: =>

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -80,17 +80,6 @@ class Player
       width = @width
       height = @height
 
-    realAspectRatio = width / height
-    nativeAspectRatio = @video.videoWidth / @video.videoHeight
-
-    # if the player is wider than necessary, fit by height
-    if realAspectRatio > nativeAspectRatio
-      width = Math.round(height * nativeAspectRatio)
-      height = height
-    else # taller than necessary
-      width = width
-      height = Math.round(width / nativeAspectRatio)
-
     @container.style.width = width + "px"
     @container.style.height = height + "px"
     return [width, height]


### PR DESCRIPTION
Having the player shape itself to remove letter-boxing causes the player to appear as though it doesn't belong. Having the player fill all available space looks more intentional and less as though something was broken
